### PR TITLE
fix: add ContextHelpers type

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -91,7 +91,7 @@ async function cli(args: ParsedArgs) {
 
   const api = await getApiDefinitions(args.remote_api_defs)
 
-  const selectedCommand = await interactForCommandSelection(api, args._)
+  const selectedCommand = await interactForCommandSelection(args._, { api })
   if (isEqual(selectedCommand, ["login"])) {
     if (args.server) {
       config.set("server", args.server)
@@ -129,11 +129,7 @@ async function cli(args: ParsedArgs) {
     return
   }
 
-  const params = await interactForCommandParams(
-    api,
-    selectedCommand,
-    commandParams
-  )
+  const params = await interactForCommandParams(selectedCommand, commandParams)
   const seam = await getSeam()
 
   const apiPath = `/${selectedCommand.join("/").replace(/-/g, "_")}`

--- a/lib/get-command-open-api-def.ts
+++ b/lib/get-command-open-api-def.ts
@@ -1,10 +1,11 @@
 import { ApiDefinitions } from "./get-api-definitions"
+import { ContextHelpers } from "./types"
 export const getCommandOpenApiDef = async (
-  api: ApiDefinitions,
-  cmd: string[]
+  cmd: string[],
+  helpers: ContextHelpers
 ) => {
   const path = `/${cmd.join("/").replace(/-/g, "_")}`
-  const def = api.paths![path]
+  const def = helpers.api.paths![path]
   if (!def) {
     throw new Error(`No definition for path ${path}`)
   }

--- a/lib/interact-for-command-params.ts
+++ b/lib/interact-for-command-params.ts
@@ -11,6 +11,7 @@ import { interactForAcsSystem } from "./interact-for-acs-system"
 import { interactForAcsUser } from "./interact-for-acs-user"
 import { interactForCredentialPool } from "./interact-for-credential-pool"
 import { ApiDefinitions } from "./get-api-definitions"
+import { ContextHelpers } from "./types"
 
 const ergonomicPropOrder = [
   "name",
@@ -21,12 +22,12 @@ const ergonomicPropOrder = [
 ]
 
 export const interactForCommandParams = async (
-  api: ApiDefinitions,
   cmd: string[],
-  currentParams: any = {}
+  currentParams: ContextHelpers & Record<string, any>
 ): Promise<any> => {
-  const requestBody = ((await getCommandOpenApiDef(api, cmd)).post as any)
-    ?.requestBody
+  const requestBody = (
+    (await getCommandOpenApiDef(cmd, currentParams)).post as any
+  )?.requestBody
 
   if (!requestBody) return ""
 
@@ -93,40 +94,40 @@ export const interactForCommandParams = async (
 
   if (paramToEdit === "device_id") {
     const device_id = await interactForDevice()
-    return interactForCommandParams(api, cmd, { ...currentParams, device_id })
+    return interactForCommandParams(cmd, { ...currentParams, device_id })
   } else if (paramToEdit === "access_code_id") {
-    const access_code_id = await interactForAccessCode(currentParams)
-    return interactForCommandParams(api, cmd, {
+    const access_code_id = await interactForAccessCode(currentParams as any)
+    return interactForCommandParams(cmd, {
       ...currentParams,
       access_code_id,
     })
   } else if (paramToEdit === "connected_account_id") {
     const connected_account_id = await interactForConnectedAccount()
-    return interactForCommandParams(api, cmd, {
+    return interactForCommandParams(cmd, {
       ...currentParams,
       connected_account_id,
     })
   } else if (paramToEdit === "user_identity_id") {
     const user_identity_id = await interactForUserIdentity()
-    return interactForCommandParams(api, cmd, {
+    return interactForCommandParams(cmd, {
       ...currentParams,
       user_identity_id,
     })
   } else if (paramToEdit.endsWith("acs_system_id")) {
     const acs_system_id = await interactForAcsSystem()
-    return interactForCommandParams(api, cmd, {
+    return interactForCommandParams(cmd, {
       ...currentParams,
       [paramToEdit]: acs_system_id,
     })
   } else if (paramToEdit.endsWith("credential_pool_id")) {
     const credential_pool_id = await interactForCredentialPool()
-    return interactForCommandParams(api, cmd, {
+    return interactForCommandParams(cmd, {
       ...currentParams,
       [paramToEdit]: credential_pool_id,
     })
   } else if (paramToEdit.endsWith("acs_user_id")) {
     const acs_user_id = await interactForAcsUser()
-    return interactForCommandParams(api, cmd, {
+    return interactForCommandParams(cmd, {
       ...currentParams,
       [paramToEdit]: acs_user_id,
     })
@@ -138,7 +139,7 @@ export const interactForCommandParams = async (
     paramToEdit.endsWith("_after")
   ) {
     const tsval = await interactForTimestamp()
-    return interactForCommandParams(api, cmd, {
+    return interactForCommandParams(cmd, {
       ...currentParams,
       [paramToEdit]: tsval,
     })
@@ -168,7 +169,7 @@ export const interactForCommandParams = async (
           })
         ).value
       }
-      return interactForCommandParams(api, cmd, {
+      return interactForCommandParams(cmd, {
         ...currentParams,
         [paramToEdit]: value,
       })
@@ -180,7 +181,7 @@ export const interactForCommandParams = async (
         initial: true,
       })
 
-      return interactForCommandParams(api, cmd, {
+      return interactForCommandParams(cmd, {
         ...currentParams,
         [paramToEdit]: value,
       })
@@ -196,7 +197,7 @@ export const interactForCommandParams = async (
           })),
         })
       ).value
-      return interactForCommandParams(api, cmd, {
+      return interactForCommandParams(cmd, {
         ...currentParams,
         [paramToEdit]: value,
       })

--- a/lib/interact-for-command-selection.ts
+++ b/lib/interact-for-command-selection.ts
@@ -2,6 +2,7 @@ import prompts from "prompts"
 import uniqBy from "lodash/uniqBy"
 import isEqual from "lodash/isEqual"
 import { ApiDefinitions } from "./get-api-definitions"
+import { ContextHelpers } from "./types"
 
 const ergonomicOrder = ["create", "list", "get", "update", "unlock_door"]
 
@@ -15,10 +16,10 @@ function ergonomicSort(aStr: string, bStr: string) {
 }
 
 export async function interactForCommandSelection(
-  api: ApiDefinitions,
-  commandPath: string[]
+  commandPath: string[],
+  helpers: ContextHelpers
 ) {
-  const commands = Object.keys(api.paths!)
+  const commands = Object.keys(helpers.api.paths!)
     .map((k) => k.replace(/_/g, "-").replace(/^\//, "").split("/"))
     .concat([
       ["login"],
@@ -76,7 +77,7 @@ export async function interactForCommandSelection(
   )
 
   if (!fullCommand) {
-    return interactForCommandSelection(api, newCommandPath)
+    return interactForCommandSelection(newCommandPath, helpers)
   }
 
   return fullCommand

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,5 @@
+import { ApiDefinitions } from "./get-api-definitions"
+
+export interface ContextHelpers {
+  api: ApiDefinitions
+}


### PR DESCRIPTION
closes https://github.com/seamapi/seam-cli/issues/31

For functions that already accept 2 args, such as `interactForCommandParams`, I've opted to have the second arg extend `ContextHelpers` instead. i.e., each func should have at most 2 args.

```ts
export const interactForCommandParams = async (
  cmd: string[],
  currentParams: ContextHelpers & Record<string, any>
): Promise<any>
```