### PR TITLE
fix: logging request params including context

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -84,7 +84,9 @@ async function cli(args: ParsedArgs) {
 
   const api = await getApiDefinitions(args.remote_api_defs)
 
-  const commandParams: ContextHelpers & Record<string, any> = {
+  const commandParams: Record<string, any> = {}
+
+  const ctx: ContextHelpers = {
     api,
   }
 
@@ -96,7 +98,7 @@ async function cli(args: ParsedArgs) {
     commandParams[k.replace(/-/g, "_")] = v
   }
 
-  const selectedCommand = await interactForCommandSelection(args._, { api })
+  const selectedCommand = await interactForCommandSelection(args._, ctx)
   if (isEqual(selectedCommand, ["login"])) {
     if (args.server) {
       config.set("server", args.server)
@@ -134,7 +136,10 @@ async function cli(args: ParsedArgs) {
     return
   }
 
-  const params = await interactForCommandParams(selectedCommand, commandParams)
+  const params = await interactForCommandParams(
+    { command: selectedCommand, params: commandParams },
+    ctx
+  )
   const seam = await getSeam()
 
   const apiPath = `/${selectedCommand.join("/").replace(/-/g, "_")}`

--- a/lib/interact-for-command-params.ts
+++ b/lib/interact-for-command-params.ts
@@ -22,12 +22,15 @@ const ergonomicPropOrder = [
 ]
 
 export const interactForCommandParams = async (
-  cmd: string[],
-  currentParams: ContextHelpers & Record<string, any>
+  args: {
+    command: string[]
+    params: Record<string, any>
+  },
+  ctx: ContextHelpers
 ): Promise<any> => {
-  const requestBody = (
-    (await getCommandOpenApiDef(cmd, currentParams)).post as any
-  )?.requestBody
+  const { command, params: currentParams } = args
+  const requestBody = ((await getCommandOpenApiDef(command, ctx)).post as any)
+    ?.requestBody
 
   if (!requestBody) return ""
 
@@ -54,7 +57,7 @@ export const interactForCommandParams = async (
     return ergonomicPropOrder.indexOf(prop)
   }
 
-  const cmdPath = `/${cmd.join("/").replace(/-/g, "_")}`
+  const cmdPath = `/${command.join("/").replace(/-/g, "_")}`
   console.log("")
   const { paramToEdit } = await prompts({
     name: "paramToEdit",
@@ -94,43 +97,82 @@ export const interactForCommandParams = async (
 
   if (paramToEdit === "device_id") {
     const device_id = await interactForDevice()
-    return interactForCommandParams(cmd, { ...currentParams, device_id })
+    return interactForCommandParams(
+      { command, params: { ...currentParams, device_id } },
+      ctx
+    )
   } else if (paramToEdit === "access_code_id") {
     const access_code_id = await interactForAccessCode(currentParams as any)
-    return interactForCommandParams(cmd, {
-      ...currentParams,
-      access_code_id,
-    })
+    return interactForCommandParams(
+      {
+        command,
+        params: {
+          ...currentParams,
+          access_code_id,
+        },
+      },
+      ctx
+    )
   } else if (paramToEdit === "connected_account_id") {
     const connected_account_id = await interactForConnectedAccount()
-    return interactForCommandParams(cmd, {
-      ...currentParams,
-      connected_account_id,
-    })
+    return interactForCommandParams(
+      {
+        command,
+        params: {
+          ...currentParams,
+          connected_account_id,
+        },
+      },
+      ctx
+    )
   } else if (paramToEdit === "user_identity_id") {
     const user_identity_id = await interactForUserIdentity()
-    return interactForCommandParams(cmd, {
-      ...currentParams,
-      user_identity_id,
-    })
+    return interactForCommandParams(
+      {
+        command,
+        params: {
+          ...currentParams,
+          user_identity_id,
+        },
+      },
+      ctx
+    )
   } else if (paramToEdit.endsWith("acs_system_id")) {
     const acs_system_id = await interactForAcsSystem()
-    return interactForCommandParams(cmd, {
-      ...currentParams,
-      [paramToEdit]: acs_system_id,
-    })
+    return interactForCommandParams(
+      {
+        command,
+        params: {
+          ...currentParams,
+          [paramToEdit]: acs_system_id,
+        },
+      },
+      ctx
+    )
   } else if (paramToEdit.endsWith("credential_pool_id")) {
     const credential_pool_id = await interactForCredentialPool()
-    return interactForCommandParams(cmd, {
-      ...currentParams,
-      [paramToEdit]: credential_pool_id,
-    })
+    return interactForCommandParams(
+      {
+        command,
+        params: {
+          ...currentParams,
+          [paramToEdit]: credential_pool_id,
+        },
+      },
+      ctx
+    )
   } else if (paramToEdit.endsWith("acs_user_id")) {
     const acs_user_id = await interactForAcsUser()
-    return interactForCommandParams(cmd, {
-      ...currentParams,
-      [paramToEdit]: acs_user_id,
-    })
+    return interactForCommandParams(
+      {
+        command,
+        params: {
+          ...currentParams,
+          [paramToEdit]: acs_user_id,
+        },
+      },
+      ctx
+    )
   } else if (
     // TODO replace when openapi returns if a field is a timestamp
     paramToEdit.endsWith("_at") ||
@@ -139,10 +181,16 @@ export const interactForCommandParams = async (
     paramToEdit.endsWith("_after")
   ) {
     const tsval = await interactForTimestamp()
-    return interactForCommandParams(cmd, {
-      ...currentParams,
-      [paramToEdit]: tsval,
-    })
+    return interactForCommandParams(
+      {
+        command,
+        params: {
+          ...currentParams,
+          [paramToEdit]: tsval,
+        },
+      },
+      ctx
+    )
   }
 
   if ("type" in prop) {
@@ -169,10 +217,16 @@ export const interactForCommandParams = async (
           })
         ).value
       }
-      return interactForCommandParams(cmd, {
-        ...currentParams,
-        [paramToEdit]: value,
-      })
+      return interactForCommandParams(
+        {
+          command,
+          params: {
+            ...currentParams,
+            [paramToEdit]: value,
+          },
+        },
+        ctx
+      )
     } else if (prop.type === "boolean") {
       const { value } = await prompts({
         name: "value",
@@ -181,10 +235,16 @@ export const interactForCommandParams = async (
         initial: true,
       })
 
-      return interactForCommandParams(cmd, {
-        ...currentParams,
-        [paramToEdit]: value,
-      })
+      return interactForCommandParams(
+        {
+          command,
+          params: {
+            ...currentParams,
+            [paramToEdit]: value,
+          },
+        },
+        ctx
+      )
     } else if (prop.type === "array") {
       const value = (
         await prompts({
@@ -197,10 +257,16 @@ export const interactForCommandParams = async (
           })),
         })
       ).value
-      return interactForCommandParams(cmd, {
-        ...currentParams,
-        [paramToEdit]: value,
-      })
+      return interactForCommandParams(
+        {
+          command,
+          params: {
+            ...currentParams,
+            [paramToEdit]: value,
+          },
+        },
+        ctx
+      )
     }
   }
 


### PR DESCRIPTION
Bundling the context with params resulted in logging params including the context (incorrectly). The context should be immutable anyway, so this PR refactors it into it's own separate arg.

### Before

![CleanShot 2023-12-20 at 10 34 36@2x](https://github.com/seamapi/seam-cli/assets/11449462/f56a4bd4-d297-4210-b562-e564d3ec761a)

### After

![CleanShot 2023-12-20 at 10 33 46@2x](https://github.com/seamapi/seam-cli/assets/11449462/1512d648-0221-457f-8a0e-32b03a9a7690)
