### PR TITLE
Use isApiKey to return SeamHttp or SeamHttpMultiWorkspace

### DIFF
--- a/lib/get-api-definitions.ts
+++ b/lib/get-api-definitions.ts
@@ -13,7 +13,9 @@ export const getApiDefinitions = async (
   return SwaggerParser.dereference(schema as unknown as OpenAPI.Document)
 }
 
-const getSchema = async (useRemoteDefinitions: boolean): typeof openapi => {
+const getSchema = async (
+  useRemoteDefinitions: boolean
+): Promise<typeof openapi> => {
   if (!useRemoteDefinitions) return openapi
   const endpoint = getServer()
   return getOpenapiSchema(endpoint)

--- a/lib/get-seam.ts
+++ b/lib/get-seam.ts
@@ -27,12 +27,5 @@ export const getSeamMultiWorkspace =
     const config = getConfigStore()
     const token = config.get(`${getServer()}.pat`)
     const options = { endpoint: getServer() }
-    try {
-      return SeamHttpMultiWorkspace.fromPersonalAccessToken(token, options)
-    } catch (e: any) {
-      if (e.toString().includes("SeamHttpInvalidTokenError")) {
-        return getSeam() as any
-      }
-      throw e
-    }
+    return SeamHttpMultiWorkspace.fromPersonalAccessToken(token, options)
   }

--- a/lib/get-seam.ts
+++ b/lib/get-seam.ts
@@ -1,4 +1,8 @@
-import { SeamHttp, SeamHttpMultiWorkspace } from "@seamapi/http/connect"
+import {
+  SeamHttp,
+  SeamHttpMultiWorkspace,
+  isApiKey,
+} from "@seamapi/http/connect"
 import { getConfigStore } from "./get-config-store"
 import { getServer } from "./get-server"
 
@@ -22,10 +26,12 @@ export const getSeam = async (): Promise<SeamHttp> => {
   return SeamHttp.fromApiKey(token, options)
 }
 
-export const getSeamMultiWorkspace =
-  async (): Promise<SeamHttpMultiWorkspace> => {
-    const config = getConfigStore()
-    const token = config.get(`${getServer()}.pat`)
-    const options = { endpoint: getServer() }
-    return SeamHttpMultiWorkspace.fromPersonalAccessToken(token, options)
-  }
+export const getSeamMultiWorkspace = async (): Promise<
+  SeamHttpMultiWorkspace | SeamHttp
+> => {
+  const config = getConfigStore()
+  const token = config.get(`${getServer()}.pat`)
+  const options = { endpoint: getServer() }
+  if (isApiKey(token)) return SeamHttp.fromApiKey(token, options)
+  return SeamHttpMultiWorkspace.fromPersonalAccessToken(token, options)
+}

--- a/lib/interact-for-workspace-id.ts
+++ b/lib/interact-for-workspace-id.ts
@@ -4,7 +4,6 @@ import { getSeamMultiWorkspace } from "./get-seam"
 
 export const interactForWorkspaceId = async () => {
   const config = getConfigStore()
-
   const seam = await getSeamMultiWorkspace()
   const workspaces = await seam.workspaces.list()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "seam-cli",
       "version": "0.0.24",
       "dependencies": {
-        "@seamapi/http": "^0.11.1",
+        "@seamapi/http": "^0.12.0",
         "@seamapi/types": "^1.70.0",
         "ms": "^2.1.3",
         "swagger-parser": "^10.0.3"
@@ -765,9 +765,9 @@
       ]
     },
     "node_modules/@seamapi/http": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@seamapi/http/-/http-0.11.1.tgz",
-      "integrity": "sha512-X/Yo60cCqPwBtggQGwqIfzk2QwoBkEWjuQrRHmRpBCD7oopfFUaRTAch7pgqiLsVtJ0i0xe6CBuN/++xrOJ3Kw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/http/-/http-0.12.0.tgz",
+      "integrity": "sha512-xOMvi3e8joBPVQ4I38FtZUBGFKuRIX7q6pIe+ik1UblRZzF+O7h77W97GMWF4WVavM5GNNVJjiCVoU6NkwBv3w==",
       "dependencies": {
         "axios": "^1.5.0",
         "axios-better-stacktrace": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@seamapi/http": "^0.11.1",
+    "@seamapi/http": "^0.12.0",
     "@seamapi/types": "^1.70.0",
     "ms": "^2.1.3",
     "swagger-parser": "^10.0.3"


### PR DESCRIPTION
- Revert "fix workspace selection when using api key (#55)"
- Use isApiKey to return SeamHttp or SeamHttpMultiWorkspace
