### PR TITLE
fix: user_identity type missing first_name & last_name

### DIFF
--- a/lib/interact-for-user-identity.ts
+++ b/lib/interact-for-user-identity.ts
@@ -11,7 +11,7 @@ export const interactForUserIdentity = async () => {
     type: "autocomplete",
     message: "Select a user_identity:",
     choices: uis.map((ui) => ({
-      title: `${ui.email_address} "${ui.first_name} ${ui.last_name}": ${ui.user_identity_key}`,
+      title: `${ui.email_address} "${ui.full_name}": ${ui.user_identity_key}`,
       value: ui.user_identity_id,
       description: ui.user_identity_id,
     })),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.27",
       "dependencies": {
         "@seamapi/http": "^0.12.0",
-        "@seamapi/types": "^1.75.0",
+        "@seamapi/types": "^1.79.0",
         "open": "^10.0.2",
         "swagger-parser": "^10.0.3"
       },
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@seamapi/types": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/types/-/types-1.75.0.tgz",
-      "integrity": "sha512-oIFgwjaYkO8vjQkw7CPGNGru6FN9zhCrmdrb7HiHLZ/ciYQyihbhQZcf0Pj/+NQn/PQjw8EWDFFU9PnXe4T0cA==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/types/-/types-1.79.0.tgz",
+      "integrity": "sha512-P4zAnCCxSjKKJdIMN1YQfXXmTJDLgHd4BdGJcoqUU30Ujq1awIqOplfe/diSoRLjN8KjC0Rl4JZYH3fUEDsDmg==",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">= 9.0.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@seamapi/http": "^0.12.0",
-    "@seamapi/types": "^1.75.0",
+    "@seamapi/types": "^1.79.0",
     "open": "^10.0.2",
     "swagger-parser": "^10.0.3"
   }


### PR DESCRIPTION
No open issue, but noticed that latest `user_identity` type doesn't actually contain `first_name` & `last_name` fields

![CleanShot 2024-01-04 at 14 44 44@2x](https://github.com/seamapi/seam-cli/assets/11449462/bd2cf0a6-cb12-4275-8378-1860698cbfae)
