### PR TITLE
feat: add use_remote_api_defs config

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -16,6 +16,7 @@ import { getApiDefinitions } from "./lib/get-api-definitions"
 import commandLineUsage from "command-line-usage"
 import { ContextHelpers } from "./lib/types"
 import { version } from "./package.json"
+import { interactForUseRemoteApiDefs } from "./lib/interact-for-use-remote-api-defs"
 
 const sections = [
   {
@@ -89,7 +90,10 @@ async function cli(args: ParsedArgs) {
     args[k.toLowerCase().replace(/-/g, "_")] = args[k]
   }
 
-  const api = await getApiDefinitions(args.remote_api_defs)
+  const use_remote_api_defs =
+    args.remote_api_defs ?? config.get("use_remote_api_defs")
+
+  const api = await getApiDefinitions(use_remote_api_defs ?? false)
 
   const commandParams: Record<string, any> = {}
 
@@ -129,6 +133,9 @@ async function cli(args: ParsedArgs) {
     return
   } else if (isEqual(selectedCommand, ["config", "reveal-location"])) {
     console.log(config.path)
+    return
+  } else if (isEqual(selectedCommand, ["config", "use-remote-api-defs"])) {
+    await interactForUseRemoteApiDefs()
     return
   } else if (isEqual(selectedCommand, ["select", "workspace"])) {
     await interactForWorkspaceId()

--- a/lib/interact-for-command-selection.ts
+++ b/lib/interact-for-command-selection.ts
@@ -25,6 +25,7 @@ export async function interactForCommandSelection(
       ["login"],
       ["logout"],
       ["config", "reveal-location"],
+      ["config", "use-remote-api-defs"],
       ["select", "workspace"],
       ["select", "server"],
     ])

--- a/lib/interact-for-use-remote-api-defs.ts
+++ b/lib/interact-for-use-remote-api-defs.ts
@@ -1,0 +1,26 @@
+import prompts from "prompts"
+import { getConfigStore } from "./get-config-store"
+
+export async function interactForUseRemoteApiDefs() {
+  const { use_remote_api_defs } = await prompts([
+    {
+      type: "select",
+      name: "use_remote_api_defs",
+      message: "Always use remote API Definitions?",
+      choices: [
+        {
+          title: "Yes",
+          value: true,
+        },
+        {
+          title: "No",
+          value: false,
+        },
+      ],
+    },
+  ])
+
+  const config = getConfigStore()
+  config.set("use_remote_api_defs", use_remote_api_defs)
+  console.log(`Use remote API Definitions: ${use_remote_api_defs}`)
+}


### PR DESCRIPTION
closes #64 

Configurable via **config > use-remote-api-defs**

### Screenshots

![CleanShot 2024-01-17 at 17 52 44](https://github.com/seamapi/seam-cli/assets/11449462/281268a5-dca3-4fdd-9e6f-f6566c0dc94c)


_Fails as expected because connect wasn't running locally._
