### PR TITLE
feat: add ability to set/remove object params (set custom_metadata)

### DIFF
--- a/lib/interact-for-open-api-object.ts
+++ b/lib/interact-for-open-api-object.ts
@@ -124,6 +124,19 @@ export const interactForOpenApiObject = async (
     ],
   })
 
+  if (paramToEdit === undefined) {
+    return args.params
+  }
+
+  if (paramToEdit === "empty") {
+    return undefined
+  }
+
+  if (paramToEdit === "done") {
+    // TODO check for required
+    return args.params
+  }
+
   if (paramToEdit === "set_property") {
     const name = (
       await prompts({
@@ -160,19 +173,6 @@ export const interactForOpenApiObject = async (
 
     const { [name]: _, ...otherParams } = args.params
     return otherParams
-  }
-
-  if (paramToEdit === undefined) {
-    return args.params
-  }
-
-  if (paramToEdit === "empty") {
-    return undefined
-  }
-
-  if (paramToEdit === "done") {
-    // TODO check for required
-    return args.params
   }
 
   const prop = properties[paramToEdit]

--- a/lib/interact-for-open-api-object.ts
+++ b/lib/interact-for-open-api-object.ts
@@ -74,6 +74,22 @@ export const interactForOpenApiObject = async (
       ...(haveAllRequiredParams && args.isSubProperty
         ? [
             {
+              title: `[Set Property]`,
+              value: "set_property",
+            },
+          ]
+        : []),
+      ...(haveAllRequiredParams && args.isSubProperty
+        ? [
+            {
+              title: `[Remove Property]`,
+              value: "remove_property",
+            },
+          ]
+        : []),
+      ...(haveAllRequiredParams && args.isSubProperty
+        ? [
+            {
               title: `[Save]`,
               value: "done",
             },
@@ -107,6 +123,48 @@ export const interactForOpenApiObject = async (
         : []),
     ],
   })
+
+  if (paramToEdit === "set_property") {
+    const name = (
+      await prompts({
+        name: "value",
+        message: "property?",
+        type: "text",
+      })
+    ).value
+
+    const value = (
+      await prompts({
+        name: "value",
+        message: "value?",
+        type: "text",
+      })
+    ).value
+
+    args.params[name] = value
+
+    return {
+      ...args.params,
+      [name]: value,
+    }
+  }
+
+  if (paramToEdit === "remove_property") {
+    const name = (
+      await prompts({
+        name: "value",
+        message: "name?",
+        type: "text",
+      })
+    ).value
+
+    const { [name]: _, ...otherParams } = args.params
+    return otherParams
+  }
+
+  if (paramToEdit === undefined) {
+    return args.params
+  }
 
   if (paramToEdit === "empty") {
     return undefined
@@ -225,7 +283,7 @@ export const interactForOpenApiObject = async (
       args.params[paramToEdit] = await interactForOpenApiObject(
         {
           command: args.command,
-          params: {},
+          params: args.params[paramToEdit] ?? {},
           schema: prop,
           isSubProperty: true,
           subPropertyPath: paramToEdit,


### PR DESCRIPTION
closes #74 

The error was actually due to not selecting a valid param because the cli was performing a search (not a text input).

Handled this via:

```
  if (paramToEdit === undefined) {
    return args.params
  }
```

Which basically just returns existing params gracefully instead.

This PR also adds the ability to set/remove properties on an `object` type param.

### Screenshots


https://github.com/seamapi/seam-cli/assets/11449462/36b40646-ff41-4b9b-b455-7cd295a407fc

