### PR TITLE
Fix `[Back]` command bug where using a full command path made the CLI act in an unintended way

### DIFF
--- a/lib/interact-for-command-selection.ts
+++ b/lib/interact-for-command-selection.ts
@@ -30,12 +30,6 @@ export async function interactForCommandSelection(
       ["select", "server"],
     ])
 
-  // Add dynamic 'back' command for sub-commands to allow returning
-  // to previous level.
-  if (commandPath.length > 0) {
-    commands.push([...commandPath, "[Back]"])
-  }
-
   const possibleCommands = uniqBy(
     commandPath.length === 0
       ? commands
@@ -54,6 +48,13 @@ export async function interactForCommandSelection(
   ) {
     return commandPath
   }
+
+  // Add dynamic 'back' command for sub-commands to allow returning
+  // to previous level.
+  if (commandPath.length > 0) {
+    possibleCommands.push([...commandPath, "[Back]"])
+  }
+
   const commandPathStr = commandPath.join("/").replace(/-/g, "_")
 
   const res = await prompts({


### PR DESCRIPTION
When running `npm run cli access_codes list`, no params to edit where showing up. Turned out, the `[Back]` command was messing it up.

Before:

https://github.com/seamapi/seam-cli/assets/84702959/178d191b-749d-4584-9471-873ef08f0153

After:

https://github.com/seamapi/seam-cli/assets/84702959/1360d57f-e248-4279-acaf-58f29afaa089


