### PR TITLE
Fix action attempt poll logic

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -18,6 +18,7 @@ import { ContextHelpers } from "./lib/types"
 import { version } from "./package.json"
 import { interactForUseRemoteApiDefs } from "./lib/interact-for-use-remote-api-defs"
 import { randomBytes } from "node:crypto"
+import { interactForActionAttemptPoll } from "./lib/interact-for-action-attempt-poll"
 
 const sections = [
   {
@@ -245,23 +246,12 @@ async function cli(args: ParsedArgs) {
     }
   }
 
-  if ("action_attempt" in response.data) {
-    const { poll_for_action_attempt } = await prompts({
-      name: "poll_for_action_attempt",
-      message: "Would you like to poll the action attempt until it's ready?",
-      type: "toggle",
-      initial: true,
-      active: "yes",
-      inactive: "no",
-    })
-
-    if (poll_for_action_attempt) {
-      const { action_attempt_id } = response.data.action_attempt
-      await seam.actionAttempts.get(
-        { action_attempt_id },
-        { waitForActionAttempt: { pollingInterval: 240, timeout: 10_000 } }
-      )
-    }
+  if (
+    response.data &&
+    typeof response.data === "object" &&
+    "action_attempt" in response.data
+  ) {
+    interactForActionAttemptPoll(response.data.action_attempt)
   }
 }
 

--- a/lib/interact-for-action-attempt-poll.ts
+++ b/lib/interact-for-action-attempt-poll.ts
@@ -1,0 +1,30 @@
+import prompts from "prompts"
+import { getSeam } from "./get-seam"
+import { ActionAttemptsGetResponse } from "@seamapi/http/connect"
+
+export const interactForActionAttemptPoll = async (
+  action_attempt: ActionAttemptsGetResponse["action_attempt"]
+) => {
+  if (action_attempt.status === "pending") {
+    const { poll_for_action_attempt } = await prompts({
+      name: "poll_for_action_attempt",
+      message: "Would you like to poll the action attempt until it's ready?",
+      type: "toggle",
+      initial: true,
+      active: "yes",
+      inactive: "no",
+    })
+
+    if (poll_for_action_attempt) {
+      const seam = await getSeam()
+      const { action_attempt_id } = action_attempt
+
+      const updated_action_attempt = await seam.actionAttempts.get(
+        { action_attempt_id },
+        { waitForActionAttempt: { pollingInterval: 240, timeout: 10_000 } }
+      )
+
+      console.dir(updated_action_attempt, { depth: null })
+    }
+  }
+}


### PR DESCRIPTION
`response.data` can be a status code in case of an unsuccessful response and it will throw when using `in` operator on a number. Also added a condition to check that `action_attempt.status` is `pending` before prompting. And finally added logging for updated action attempt to see the result of the poll.