### PR TITLE
Fix: sign MacOS binaries during build and release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -27,7 +27,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libssl-dev
           git clone https://github.com/sbingner/ldid.git
-          cd ldid
           make -C ldid
           sudo cp -f ./ldid/ldid /usr/local/bin/
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   push:
     branches:
-      - sign_macos_binaries_in_workflow
+      - main
 
 jobs:
   build-and-release:
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        if: github.ref == 'refs/heads/sign_macos_binaries_in_workflow'
+        if: github.ref == 'refs/heads/main'
         uses: actions/create-release@v1
         with:
           tag_name: ${{ env.VERSION_TAG }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install ldid
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev
+          sudo apt-get install -y libssl-dev libplist-dev
           git clone https://github.com/sbingner/ldid.git
           make -C ldid
           sudo cp -f ./ldid/ldid /usr/local/bin/

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   push:
     branches:
-      - main
+      - sign_macos_binaries_in_workflow
 
 jobs:
   build-and-release:
@@ -21,6 +21,15 @@ jobs:
         run: npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+      - name: Install ldid
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev
+          git clone https://github.com/sbingner/ldid.git
+          cd ldid
+          make -C ldid
+          sudo cp -f ./ldid/ldid /usr/local/bin/
 
       - name: Build the project
         run: npm run build

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/sign_macos_binaries_in_workflow'
         uses: actions/create-release@v1
         with:
           tag_name: ${{ env.VERSION_TAG }}


### PR DESCRIPTION
I've set up the Build-and-release workflow to run on my local branch and got it to sign the MacOS binary.
<img width="1235" alt="Screenshot 2024-02-27 at 02 22 49" src="https://github.com/seamapi/seam-cli/assets/41388251/c46fc879-18f8-4aaa-be42-e346974d09fb">
