### PR TITLE
add registry-url to Node setup

### DIFF
--- a/.github/workflows/build-release-publish.yml
+++ b/.github/workflows/build-release-publish.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "18"
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
https://github.com/npm/cli/issues/6184 I think registry-url has to be specified in order to release to npm