### PR TITLE
feat: auto-submit on -y flag

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -115,8 +115,14 @@ async function cli(args: ParsedArgs) {
 
   const commandParams: Record<string, any> = {}
 
+  /**
+   * Whether or not to auto-select first option
+   */
+  const is_interactive = args.y !== true
+
   const ctx: ContextHelpers = {
     api,
+    is_interactive,
   }
 
   for (const k in args) {

--- a/lib/interact-for-open-api-object.ts
+++ b/lib/interact-for-open-api-object.ts
@@ -46,6 +46,12 @@ export const interactForOpenApiObject = async (
 
   const haveAllRequiredParams = required.every((k) => args.params[k])
 
+  const should_auto_submit =
+    !ctx.is_interactive && haveAllRequiredParams && !args.isSubProperty
+  if (should_auto_submit) {
+    return args.params
+  }
+
   const propSortScore = (prop: string) => {
     if (required.includes(prop)) return 100 - ergonomicPropOrder.indexOf(prop)
     if (args.params[prop] !== undefined)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,4 +2,5 @@ import { ApiDefinitions } from "./get-api-definitions"
 
 export interface ContextHelpers {
   api: ApiDefinitions
+  is_interactive: boolean
 }


### PR DESCRIPTION
closes #32 

### Notable Things

Currently only handles submitting API calls. @seveibar , Any other cases we should auto-submit / auto-select?

### Screenshots / Demo

https://github.com/seamapi/seam-cli/assets/11449462/f131d73b-f9be-466b-bb4a-f1f1354cd2c2

