### PR TITLE
fix(Login): update link for access tokens

### DIFF
--- a/lib/interact-for-login.ts
+++ b/lib/interact-for-login.ts
@@ -12,7 +12,9 @@ export const interactForLogin = async () => {
       `You're using a local Seam Connect instance, you can enter the API Key to your local user, you can create a new user from:\n\n${getServer()}/admin/create_user_with_api_key`
     )
   } else {
-    console.log(`To login, navigate to your workspace settings, go to Personal Access Token (PAT), and paste the PAT in the provided box: https://console.seam.co\n\n`)
+    console.log(
+      `To login, navigate to your workspace settings, go to Personal Access Token (PAT), and paste the PAT in the provided box: https://console.seam.co\n\n`
+    )
   }
 
   console.log(

--- a/lib/interact-for-login.ts
+++ b/lib/interact-for-login.ts
@@ -12,9 +12,7 @@ export const interactForLogin = async () => {
       `You're using a local Seam Connect instance, you can enter the API Key to your local user, you can create a new user from:\n\n${getServer()}/admin/create_user_with_api_key`
     )
   } else {
-    console.log(
-      `To login, navigate to the URL below and create a new Personal Access Token (PAT) and paste the PAT in the provided box:\n\nhttps://console.seam.co/settings/access-tokens\n\n`
-    )
+    console.log(`To login, navigate to your workspace settings, go to Personal Access Token (PAT), and paste the PAT in the provided box: https://console.seam.co\n\n`)
   }
 
   console.log(


### PR DESCRIPTION
closes #257 

We have a bit of a chicken-egg problem, access tokens are now scoped to workspaces, but we can't list workspaces without logging in, which requires an access token.

The best we can do is provide a generic message here to access their Workspace Settings instead of the direct link to the Workspace's access token page.