### PR TITLE
fix: remove prop descriptions

### DIFF
--- a/lib/interact-for-open-api-object.ts
+++ b/lib/interact-for-open-api-object.ts
@@ -88,19 +88,15 @@ export const interactForOpenApiObject = async (
         : []),
       ...Object.keys(properties)
         .map((k) => {
-          let propDesc = (properties[k] as any)?.description ?? ""
           return {
             title: k + (required.includes(k) ? "*" : ""),
             value: k,
             description:
               args.params[k] !== undefined
                 ? typeof args.params[k] === "object"
-                  ? `${ellipsis(
-                      JSON.stringify(args.params[k]),
-                      60
-                    )} ${propDesc}`
-                  : `[${args.params[k]}] ${propDesc}`
-                : propDesc,
+                  ? ellipsis(JSON.stringify(args.params[k]), 60)
+                  : `[${args.params[k]}]`
+                : undefined,
           }
         })
         .sort((a, b) => propSortScore(b.value) - propSortScore(a.value)),


### PR DESCRIPTION
Displaying descriptions are causing scroll issues where navigating isn't showing the selected option anymore.

<img width="1152" height="702" alt="image" src="https://github.com/user-attachments/assets/a300156a-a6ab-4012-a5fe-d2fa2ab5fc58" />
