### PR TITLE
Add Homebrew distribution support for Seam CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Install the CLI globally using [npm] with
 $ npm install --global @seamapi/cli
 ```
 
+On macOS or Linux, install with [Homebrew] using
+
+```
+$ brew install seam
+```
+
 On Arch Linux, install the [`seam-bin`][aur] package from the AUR with
 
 ```
@@ -33,6 +39,7 @@ $ paru -S seam-bin
 ```
 
 [aur]: https://aur.archlinux.org/packages/seam-bin
+[Homebrew]: https://formulae.brew.sh/formula/seam
 [npm]: https://www.npmjs.com/
 
 ## Usage


### PR DESCRIPTION
## Summary
This PR adds Homebrew as a distribution channel for the Seam CLI, enabling macOS and Linux users to install the tool via `brew install seam`.

## Key Changes
- **Automated Homebrew formula updates**: Added a new `homebrew` job in the publish workflow that automatically bumps the Homebrew formula in homebrew-core on each release
  - Waits for the npm package to be published before attempting the formula bump
  - Uses `brew bump-formula-pr` to create pull requests with updated URL and SHA256
  - Configured to only run on stable releases (excludes pre-release versions with `-` in the tag)
- **Reference formula**: Added `.github/homebrew/seam.rb` as a reference copy of the Homebrew formula that lives in homebrew-core
  - Includes installation via npm with proper symlink setup
  - Includes basic test coverage for version output and authentication check
- **Documentation**: Updated README.md to document Homebrew as an installation method alongside npm and AUR

## Implementation Details
- The workflow job depends on the npm job completing successfully before attempting the Homebrew formula bump
- The formula bump uses git credentials from secrets (`GH_TOKEN`, `GIT_USER_NAME`, `GIT_USER_EMAIL`) for authentication
- The tarball URL is automatically computed from the scoped package name, handling the scope-to-filename conversion correctly
- SHA256 validation is delegated to homebrew-core's pull request checks via the `--no-audit` flag

https://claude.ai/code/session_0144M6JQSTdYRxdw7FNsnDcN