### PR TITLE
Remove console rule exception from ESLint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,13 +17,6 @@ export default [
     },
   },
   {
-    files: ['src/bin/**/*.ts', 'src/lib/**/*.ts'],
-    rules: {
-      // TODO: Replace the console calls with a logger wrapper.
-      'no-console': 'off',
-    },
-  },
-  {
     files,
     plugins: {
       'unused-imports': unusedImports,


### PR DESCRIPTION
This change removes the ESLint configuration override that previously disabled the `no-console` rule for files in `src/bin/**/*.ts` and `src/lib/**/*.ts`.

## Summary
The exception that allowed console calls in bin and lib source files has been removed. This means the `no-console` rule will now be enforced across all TypeScript files, including those in the bin and lib directories.

## Changes
- Removed the ESLint config block that disabled `no-console` for `src/bin/**/*.ts` and `src/lib/**/*.ts` files
- The TODO comment about replacing console calls with a logger wrapper has also been removed

## Notes
This change enforces stricter linting rules across the codebase. Any existing console calls in the affected directories will now trigger ESLint errors and will need to be addressed (either by implementing a logger wrapper as previously noted, or by removing the console calls).

https://claude.ai/code/session_01SvMcZS3PArzNFjDS4qPs37