### PR TITLE
fix: Accept falsy required params and log out of the active server

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -241,7 +241,8 @@ async function cli(args: ParsedArgs) {
     return
   } else if (isEqual(selectedCommand, ['logout'])) {
     assertEnvVarUnset(tokenEnvVar, getTokenFromEnv(), 'log out')
-    config.delete('pat')
+    config.delete(`${getServer()}.pat`)
+    config.delete('current_workspace_id')
     output.info('Logged out!')
     return
   } else if (isEqual(selectedCommand, ['config', 'reveal-location'])) {

--- a/src/lib/interact-for-blueprint-object.test.ts
+++ b/src/lib/interact-for-blueprint-object.test.ts
@@ -5,7 +5,7 @@ import { interactForBlueprintObject } from './interact-for-blueprint-object.js'
 import { createMemoryOutput } from './output/create-memory-output.js'
 import { setOutput } from './output/get-output.js'
 import type { ContextHelpers } from './types.js'
-import { promptAutocomplete } from './util/prompt.js'
+import { promptAutocomplete, promptSelect } from './util/prompt.js'
 
 vi.mock('./util/prompt.js', () => ({
   canPrompt: vi.fn(() => true),
@@ -90,3 +90,87 @@ test('interactForBlueprintObject: rejects missing required parameters when non-i
   )
   expect(promptAutocomplete).not.toHaveBeenCalled()
 })
+
+const falsyParameters = [
+  { name: 'enabled', isRequired: true, format: 'boolean' },
+] as unknown as Parameter[]
+
+const falsyArgs = (params: Record<string, any>) => ({
+  command: ['devices', 'get'],
+  parameters: falsyParameters,
+  params,
+})
+
+// A required parameter is satisfied by being present, not by being truthy:
+// `false`, `0` and `''` are values a user can supply.
+test.for([
+  ['boolean', false] as const,
+  ['number', 0] as const,
+  ['string', ''] as const,
+])(
+  'interactForBlueprintObject: accepts a required falsy %s value',
+  async ([, value]) => {
+    await expect(
+      interactForBlueprintObject(falsyArgs({ enabled: value }), ctx('auto')),
+    ).resolves.toEqual({ enabled: value })
+    expect(promptAutocomplete).not.toHaveBeenCalled()
+  },
+)
+
+test('interactForBlueprintObject: reports a required parameter as missing only when absent', async () => {
+  await expect(
+    interactForBlueprintObject(falsyArgs({}), ctx('non-interactive')),
+  ).rejects.toThrowError(
+    'Missing required parameter for /devices/get: --enabled',
+  )
+})
+
+test('interactForBlueprintObject: does not report a falsy sub-property value as missing', async () => {
+  await expect(
+    interactForBlueprintObject(
+      {
+        ...falsyArgs({ enabled: false }),
+        isSubProperty: true,
+        subPropertyPath: 'inner',
+      },
+      ctx('non-interactive'),
+    ),
+  ).rejects.toThrowError('Cannot prompt for "inner" in non-interactive mode')
+})
+
+test('interactForBlueprintObject: offers the submit choice when a required value is falsy', async () => {
+  await interactForBlueprintObject(
+    falsyArgs({ enabled: false }),
+    ctx('interactive'),
+  )
+
+  const { choices } = vi.mocked(promptAutocomplete).mock.calls[0]?.[0] as {
+    choices: Array<{ value: string; label: string }>
+  }
+  expect(choices.map(({ value }) => value)).toContain('done')
+})
+
+// `custom_metadata` and `custom_metadata_has` are both records, a format with no
+// branch of its own, so each has to be routed by name.
+test.for(['custom_metadata', 'custom_metadata_has'] as const)(
+  'interactForBlueprintObject: edits %s with the metadata editor',
+  async (name) => {
+    vi.mocked(promptAutocomplete)
+      .mockImplementationOnce(async () => name as never)
+      .mockImplementationOnce(async () => 'done' as never)
+    vi.mocked(promptSelect).mockImplementation(async () => 'done' as never)
+
+    await expect(
+      interactForBlueprintObject(
+        {
+          command: ['devices', 'list'],
+          parameters: [
+            { name, isRequired: false, format: 'record' },
+          ] as unknown as Parameter[],
+          params: {},
+        },
+        ctx('interactive'),
+      ),
+    ).resolves.toEqual({ [name]: {} })
+  },
+)

--- a/src/lib/interact-for-blueprint-object.ts
+++ b/src/lib/interact-for-blueprint-object.ts
@@ -54,7 +54,9 @@ export const interactForBlueprintObject = async (
     .filter((parameter) => parameter.isRequired)
     .map((parameter) => parameter.name)
 
-  const haveAllRequiredParams = required.every((k) => args.params[k])
+  const isSupplied = (k: string): boolean => args.params[k] !== undefined
+
+  const haveAllRequiredParams = required.every(isSupplied)
 
   const cmdPath = `/${args.command.join('/').replace(/-/g, '_')}`
 
@@ -67,7 +69,7 @@ export const interactForBlueprintObject = async (
   }
 
   if (ctx.interactivity === 'non-interactive') {
-    const missing = required.filter((k) => !args.params[k])
+    const missing = required.filter((k) => !isSupplied(k))
     const target = args.isSubProperty ? `"${args.subPropertyPath}"` : cmdPath
     throw new NonInteractiveError(
       missing.length > 0
@@ -193,7 +195,10 @@ export const interactForBlueprintObject = async (
   ) {
     args.params[paramToEdit] = await interactForTimestamp()
     return interactForBlueprintObject(args, ctx)
-  } else if (paramToEdit === 'custom_metadata') {
+  } else if (
+    paramToEdit === 'custom_metadata' ||
+    paramToEdit === 'custom_metadata_has'
+  ) {
     args.params[paramToEdit] = await interactForCustomMetadata(
       args.params[paramToEdit] || {},
     )

--- a/src/lib/interact-for-custom-metadata.test.ts
+++ b/src/lib/interact-for-custom-metadata.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import { interactForCustomMetadata } from './interact-for-custom-metadata.js'
+import { createMemoryOutput } from './output/create-memory-output.js'
+import { setOutput } from './output/get-output.js'
+import { promptSelect, promptText } from './util/prompt.js'
+
+vi.mock('./util/prompt.js', () => ({
+  canPrompt: vi.fn(() => true),
+  PromptCancelledError: class extends Error {},
+  promptText: vi.fn(),
+  promptNumber: vi.fn(),
+  promptConfirm: vi.fn(),
+  promptSelect: vi.fn(),
+  promptAutocomplete: vi.fn(),
+  promptAutocompleteMultiselect: vi.fn(),
+}))
+
+/** Queues answers in the order the editor asks for them. */
+const answerSelects = (...values: string[]): void => {
+  const queue = [...values]
+  vi.mocked(promptSelect).mockImplementation(async () => queue.shift() as never)
+}
+
+const answerTexts = (...values: string[]): void => {
+  const queue = [...values]
+  vi.mocked(promptText).mockImplementation(async () => queue.shift() as never)
+}
+
+beforeEach(() => {
+  vi.mocked(promptSelect).mockReset()
+  vi.mocked(promptText).mockReset()
+  setOutput(createMemoryOutput().output)
+})
+
+test('interactForCustomMetadata: adds a key and value', async () => {
+  answerSelects('add', 'done')
+  answerTexts('floor', '3')
+
+  await expect(interactForCustomMetadata({})).resolves.toEqual({ floor: '3' })
+})
+
+test('interactForCustomMetadata: removes a key from the result', async () => {
+  answerSelects('remove', 'floor', 'done')
+
+  await expect(
+    interactForCustomMetadata({ floor: '3', wing: 'east' }),
+  ).resolves.toEqual({ wing: 'east' })
+})
+
+test('interactForCustomMetadata: leaves the given metadata unmodified', async () => {
+  answerSelects('remove', 'floor', 'done')
+  const customMetadata = { floor: '3', wing: 'east' }
+
+  await interactForCustomMetadata(customMetadata)
+
+  expect(customMetadata).toEqual({ floor: '3', wing: 'east' })
+})
+
+test.for([['true', true] as const, ['false', false] as const])(
+  'interactForCustomMetadata: stores %s as a boolean',
+  async ([given, stored]) => {
+    answerSelects('add', 'done')
+    answerTexts('enabled', given)
+
+    await expect(interactForCustomMetadata({})).resolves.toEqual({
+      enabled: stored,
+    })
+  },
+)
+
+test('interactForCustomMetadata: stores null for the null keyword', async () => {
+  answerSelects('add', 'done')
+  answerTexts('note', 'null')
+
+  await expect(interactForCustomMetadata({})).resolves.toEqual({ note: null })
+})

--- a/src/lib/interact-for-custom-metadata.ts
+++ b/src/lib/interact-for-custom-metadata.ts
@@ -50,7 +50,7 @@ export const interactForCustomMetadata = async (
       })
       if (newKey) {
         if (newValue === 'false' || newValue === 'true') {
-          newValue = Boolean(newValue)
+          newValue = newValue === 'true'
         }
         if (newValue === 'null') {
           updatedCustomMetadata[newKey] = null
@@ -69,7 +69,7 @@ export const interactForCustomMetadata = async (
         }),
       })
 
-      delete customMetadata[customKeyToRemove]
+      delete updatedCustomMetadata[customKeyToRemove]
     }
   } while (action !== 'done')
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { createServer, type Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -503,4 +503,61 @@ test('cli: reports a failed request on stdout and exits non-zero', async () => {
     error: { type: 'invalid_input', message: 'Bad request' },
   })
   expect(stderr).toContain('[400]')
+})
+
+// Logout gets its own state, since logging out of the shared one would
+// unauthenticate every other test in this file.
+const createLoggedInStateHome = async (): Promise<string> => {
+  const home = await mkdtemp(join(tmpdir(), 'seam-cli-logout-'))
+  await mkdir(join(home, 'seam'), { recursive: true })
+  await writeFile(
+    join(home, 'seam', 'cli.json'),
+    JSON.stringify({
+      [endpoint]: { pat: 'seam_apikey1_token' },
+      current_workspace_id: 'workspace1',
+    }),
+  )
+  return home
+}
+
+const readStoredState = async (home: string): Promise<unknown> =>
+  JSON.parse(await readFile(join(home, 'seam', 'cli.json'), 'utf8'))
+
+test('cli: logout removes the stored token', async () => {
+  const home = await createLoggedInStateHome()
+
+  const { exitCode } = await runCli(['logout'], { stateHome: home })
+
+  expect(exitCode).toBe(0)
+  expect(await readStoredState(home)).toEqual({ [endpoint]: {} })
+})
+
+test('cli: logout leaves the cli unauthenticated', async () => {
+  const home = await createLoggedInStateHome()
+
+  await runCli(['logout'], { stateHome: home })
+  const { stderr, exitCode } = await runCli(['devices', 'list'], {
+    stateHome: home,
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain('Not logged in')
+})
+
+test('cli: logout keeps a token stored for another server', async () => {
+  const home = await createLoggedInStateHome()
+  await writeFile(
+    join(home, 'seam', 'cli.json'),
+    JSON.stringify({
+      [endpoint]: { pat: 'seam_apikey1_token' },
+      'http://localhost:1': { pat: 'seam_apikey1_other' },
+    }),
+  )
+
+  await runCli(['logout'], { stateHome: home })
+
+  expect(await readStoredState(home)).toEqual({
+    [endpoint]: {},
+    'http://localhost:1': { pat: 'seam_apikey1_other' },
+  })
 })


### PR DESCRIPTION
## Summary

Five bugs, each with a test that fails without the fix. Six files changed, no new test infrastructure: everything here builds on the harness already on `main`.

## Bug fixes

**Required parameters were tested for truthiness** (`src/lib/interact-for-blueprint-object.ts`)

A required `false`, `0`, or empty string counted as missing. With `-y` that suppressed auto-submit and dropped into a prompt in a mode meant to be noninteractive; when interactive it removed `[Make API Call]` from the parameter menu, leaving no way to submit while the value was displayed next to the parameter. `propSortScore` and the choice hints in the same file already tested `!== undefined`, so the intended meaning was settled.

The same truthiness test decided which parameters the noninteractive error named. That path is only reachable for a sub-property, since auto-submit short-circuits otherwise, so it has its own test.

**`custom_metadata_has` crashed seven endpoints** (`src/lib/interact-for-blueprint-object.ts`)

It has format `record`, which has no branch of its own, and only `custom_metadata` was routed by name — so selecting it threw `Didn't know how to handle Blueprint parameter`. Affected `/devices/list`, `/locks/list`, `/thermostats/list`, `/noise_sensors/list`, `/devices/unmanaged/list`, `/connect_webviews/list` and `/connected_accounts/list`.

**Logout left the token on disk** (`src/bin/cli.ts`)

Credentials are written per server as `${getServer()}.pat`, but logout deleted a top-level `pat` key that nothing writes. It reported success and the next command still authenticated. It now deletes the server-scoped key and clears the selected workspace, as the login and select-server paths already do.

**Custom metadata removal did nothing** (`src/lib/interact-for-custom-metadata.ts`)

Removal deleted from the caller's object rather than the copy that is returned.

**`Boolean('false')` is `true`** (`src/lib/interact-for-custom-metadata.ts`)

Entering `false` for a metadata value stored `true`.

## Tests

- `src/lib/interact-for-blueprint-object.test.ts` — required falsy `false`/`0`/`''` accepted; a required parameter reported missing only when absent; a falsy sub-property value not reported as missing; the submit choice present when a required value is falsy; `custom_metadata` and `custom_metadata_has` both routed to the metadata editor.
- `src/lib/interact-for-custom-metadata.test.ts` (new) — add, remove-from-result, caller's object left unmodified, `'true'`/`'false'` stored as booleans, `'null'` stored as `null`.
- `test/cli.test.ts` — logout removes the stored token, leaves the CLI unauthenticated, and keeps a token stored for another server.

Each fix was verified by reverting it individually and confirming a test fails.

The logout tests build their own state directory. The shared one created in `beforeAll` holds the token nearly every other end-to-end test depends on, so logging out of it would unauthenticate the rest of the file.

## Notes

The credential key contains dots, so configstore stores it as a nested path rather than a flat key. The logout tests assert on the stored JSON to pin that, since a flat-key assertion would not catch a regression.

https://claude.ai/code/session_01JtA9VEan6WgvP6XpFvH7q5
