### PR TITLE
fix: Keep the given value when an object parameter is edited

### DIFF
--- a/src/lib/interactions/blueprint-object.ts
+++ b/src/lib/interactions/blueprint-object.ts
@@ -305,7 +305,7 @@ export const interactForBlueprintObject = async (
         args.params[paramToEdit] = await interactForBlueprintObject(
           {
             command: args.command,
-            params: {},
+            params: toObjectParams(args.params[paramToEdit]),
             parameters: prop.parameters,
             isSubProperty: true,
             subPropertyPath: paramToEdit,
@@ -332,3 +332,15 @@ export const interactForBlueprintObject = async (
     `Didn't know how to handle Blueprint parameter for property: "${paramToEdit}"`,
   )
 }
+
+/**
+ * An object parameter's value as the params its editor starts from, so
+ * editing is prefilled with what was given and leaving the editor keeps it.
+ *
+ * Params read from stdin are passed through as given, so the value is not
+ * necessarily an object: anything else has nothing to edit and starts empty.
+ */
+const toObjectParams = (value: unknown): Record<string, any> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, any>)
+    : {}

--- a/test/interactions/blueprint-object.test.ts
+++ b/test/interactions/blueprint-object.test.ts
@@ -240,6 +240,129 @@ test.for(['custom_metadata', 'custom_metadata_has'] as const)(
   },
 )
 
+// An object parameter is edited by the same menu one level down, so it has to
+// start from the value it was given rather than from nothing.
+const objectParameters = [
+  {
+    name: 'user_identity',
+    isRequired: false,
+    format: 'object',
+    parameters: [
+      { name: 'full_name', isRequired: true, format: 'string' },
+      { name: 'user_identity_key', isRequired: false, format: 'string' },
+    ],
+  },
+] as unknown as Parameter[]
+
+const userIdentity = {
+  full_name: 'Jane Doe',
+  user_identity_key: 'jane',
+}
+
+const objectArgs = (params: Record<string, any>) => ({
+  command: ['access_grants', 'create'],
+  parameters: objectParameters,
+  params,
+})
+
+const editorChoices = (): Array<{ value: string; hint?: string }> => {
+  const question = memoryPrompt.questions.find(
+    ({ message }) => message === withBackHint('Editing "user_identity"'),
+  )
+  if (question?.choices == null) throw new Error('The editor was not opened')
+  return question.choices as Array<{ value: string; hint?: string }>
+}
+
+test('interactForBlueprintObject: prefills an object parameter editor with the given value', async () => {
+  // Pick the parameter, choose to enter a value, then leave its editor.
+  scriptPrompt(['user_identity', 'value', 'back', 'done'])
+
+  await interactForBlueprintObject(
+    objectArgs({ user_identity: { ...userIdentity } }),
+    ctx('interactive'),
+  )
+
+  expect(
+    editorChoices().find(({ value }) => value === 'full_name'),
+  ).toMatchObject({ hint: '[Jane Doe]' })
+})
+
+test('interactForBlueprintObject: leaving an object parameter editor keeps the given value', async () => {
+  scriptPrompt(['user_identity', 'value', 'back', 'done'])
+
+  await expect(
+    interactForBlueprintObject(
+      objectArgs({ user_identity: { ...userIdentity } }),
+      ctx('interactive'),
+    ),
+  ).resolves.toEqual({ user_identity: userIdentity })
+})
+
+test('interactForBlueprintObject: dismissing an object parameter editor keeps the given value', async () => {
+  scriptPrompt(['user_identity', 'value', cancelPrompt, 'done'])
+
+  await expect(
+    interactForBlueprintObject(
+      objectArgs({ user_identity: { ...userIdentity } }),
+      ctx('interactive'),
+    ),
+  ).resolves.toEqual({ user_identity: userIdentity })
+})
+
+test('interactForBlueprintObject: edits an object parameter from the value it was given', async () => {
+  // Pick the parameter, enter its editor, edit one sub-property, save.
+  scriptPrompt([
+    'user_identity',
+    'value',
+    'user_identity_key',
+    'value',
+    'jane-2',
+    'done',
+    'done',
+  ])
+
+  await expect(
+    interactForBlueprintObject(
+      objectArgs({ user_identity: { ...userIdentity } }),
+      ctx('interactive'),
+    ),
+  ).resolves.toEqual({
+    user_identity: {
+      full_name: userIdentity.full_name,
+      user_identity_key: 'jane-2',
+    },
+  })
+})
+
+test('interactForBlueprintObject: an object parameter given nothing starts empty', async () => {
+  scriptPrompt(['user_identity', 'full_name', 'Jane Doe', 'done', 'done'])
+
+  await expect(
+    interactForBlueprintObject(objectArgs({}), ctx('interactive')),
+  ).resolves.toEqual({ user_identity: { full_name: 'Jane Doe' } })
+})
+
+// Params read from stdin are passed through as given, so an object parameter
+// can arrive as something with no properties to edit.
+test.for([['a string', 'nope'] as const, ['a list', ['nope']] as const])(
+  'interactForBlueprintObject: an object parameter given %s starts empty',
+  async ([, given]) => {
+    scriptPrompt(['user_identity', 'value', 'back', 'done'])
+
+    await interactForBlueprintObject(
+      objectArgs({ user_identity: given }),
+      ctx('interactive'),
+    )
+
+    expect(editorChoices().map(({ value }) => value)).toEqual([
+      'full_name',
+      'user_identity_key',
+      'empty',
+      'back',
+    ])
+  },
+)
+
 test('interactForBlueprintObject: dismissing the parameter menu leaves the command', async () => {
   scriptPrompt([cancelPrompt])
 


### PR DESCRIPTION
This PR proposes keeping the value a user gave for an object parameter when that parameter is opened in the interactive parameter menu, instead of discarding it. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/290. You can sign in with your GitHub ID to claim ownership of the project.

## What changed

`interactForBlueprintObject` opens the editor for an `object` parameter on an empty params object (`params: {}` in `src/lib/interactions/blueprint-object.ts`), so whatever the user passed for that parameter is dropped the moment they look at it. Leaving that editor with `[Back]`, or dismissing it, returns those empty params and the parent menu assigns them over the value that was given — and since the object returned by `interactForCommandParams` is the request body `api-command.ts` sends, the request goes out with `{}` in place of what the user typed. That is silent data loss on 30 request parameters in the current schema, among them `/acs/users/create --access-schedule`, `/access_grants/create --user-identity`, and the nested `--features` of `/customers/create_portal`. It also contradicts the README (`--interactive` "is prefilled with whatever you passed as arguments"), this function's own comment that dismissing a prompt returns to the menu "with the parameter left as it was", and the sibling editors: the list editor is seeded with `args.params[paramToEdit] || []` and the metadata editor with `args.params[paramToEdit] || {}`.

The fix is to seed the object editor from the current value the same way, through a small `toObjectParams` helper. Params read from stdin are passed through as given, so the value is not necessarily an object; anything that is not a plain object has nothing to edit and still starts empty, which is what the two control tests pin down. Nothing is taken away: `[Leave Empty]` still clears the whole object and `Unset` still clears a sub-property, so both ways of blanking a value keep working.

Reproduced on `main` at `34d5f84`, in your own harness — with `params: { user_identity: { full_name: 'Jane Doe', user_identity_key: 'jane' } }` in interactive mode, selecting the parameter and then leaving its editor:

```
AssertionError: expected { user_identity: {} } to deeply equal { user_identity: { …(2) } }
- Expected
+ Received
  {
-   "user_identity": {
-     "full_name": "Jane Doe",
-     "user_identity_key": "jane",
-   },
+   "user_identity": {},
  }
```

Verification: seven tests were added to `test/interactions/blueprint-object.test.ts` covering the prefill, leaving the editor, dismissing it, editing one sub-property from the given value, and the empty and non-object cases. Four of them fail on the tree without the one-line change and pass with it; the two "starts empty" cases stay green both ways, so they hold the unchanged behavior in place. `npm test`, `npm run typecheck` and `npm run lint` were run before and after: 286 tests passing before, 293 after, with the same clean type-check and lint.

## How this was managed

This work was tracked as [a story on a board](https://eastagiletracker.com/projects/290/stories/181500) imported from this repository's own issues and pull requests — 610 stories in all — and the board is live at https://eastagiletracker.com/projects/290.

![board](https://raw.githubusercontent.com/eastagiletracker/cli/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
