### PR TITLE
feat: Publish a Scoop manifest with each release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,52 @@ jobs:
         with:
           name: ${{ needs.build.outputs.artifact_name }}
           path: .
+      - name: Generate Scoop manifest
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          version="${GITHUB_REF_NAME#v}"
+          url="https://github.com/${REPOSITORY}"
+          description=$(jq --raw-output '.description' package.json)
+
+          hash=$(awk -v f="seam-v${version}-windows-x64.exe" \
+            '{file = $2; sub(/^\*/, "", file)} file == f {print $1}' \
+            release/checksums.txt)
+          test -n "$hash"
+
+          # In the autoupdate section $version is a Scoop template variable,
+          # not a shell or jq one.
+          jq --null-input \
+            --arg version "$version" \
+            --arg description "$description" \
+            --arg url "$url" \
+            --arg hash "$hash" \
+            '{
+              version: $version,
+              description: $description,
+              homepage: $url,
+              license: "MIT",
+              architecture: {
+                "64bit": {
+                  url: "\($url)/releases/download/v\($version)/seam-v\($version)-windows-x64.exe#/seam.exe",
+                  hash: $hash
+                }
+              },
+              bin: "seam.exe",
+              checkver: {github: $url},
+              autoupdate: {
+                architecture: {
+                  "64bit": {
+                    url: "\($url)/releases/download/v$version/seam-v$version-windows-x64.exe#/seam.exe"
+                  }
+                },
+                hash: {url: "\($url)/releases/download/v$version/checksums.txt"}
+              }
+            }' > release/seam.json
+
+          cat release/seam.json
       - name: Generate release notes
         id: changelog
         run: |
@@ -45,6 +91,7 @@ jobs:
           files: |
             *.tgz
             release/seam-*
+            release/seam.json
             release/checksums.txt
           body_path: ${{ github.workspace }}/${{ steps.changelog.outputs.outfile }}
   npm:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ but it does not include the Seam Wizard.
 $ brew install seam
 ```
 
+### Scoop
+
+On Windows, install the CLI from [Scoop] with
+
+```
+> scoop install https://github.com/seamapi/cli/releases/latest/download/seam.json
+```
+
+Later, update it with `scoop update seam`.
+
 ### Standalone binary
 
 Install the latest release on Linux and macOS with
@@ -104,6 +114,7 @@ npm or manual install, run `seam completion --install`.
 [Homebrew]: https://formulae.brew.sh/cask/seam
 [latest GitHub release]: https://github.com/seamapi/cli/releases/latest
 [npm]: https://www.npmjs.com/
+[Scoop]: https://scoop.sh/
 [Seam Wizard]: https://github.com/seamapi/wizard
 [shell completion]: #shell-completion
 


### PR DESCRIPTION
Add Scoop support for Windows by generating a Scoop manifest as a release asset.

## Summary

The `publish.yml` release job now generates `seam.json` — a Scoop manifest pinning the Windows binary's SHA-256 from `checksums.txt` — and uploads it alongside the other release assets. Windows users install with

```
scoop install https://github.com/seamapi/cli/releases/latest/download/seam.json
```

and update with `scoop update seam`, which re-fetches the manifest from that URL. Since `releases/latest` only points at stable releases, installs always track the newest stable version.

## Key changes

- **`.github/workflows/publish.yml`**: a `Generate Scoop manifest` step in the release job builds `release/seam.json` with `jq` (mirroring the AUR PKGBUILD generation pattern), extracting the `seam-v<version>-windows-x64.exe` hash from `checksums.txt` and failing the release if the entry is missing. The manifest is added to the uploaded release files.
- **`README.md`**: a Scoop section under Installation with the install and update commands.

## Notable details

- The `#/seam.exe` URL fragment makes Scoop rename the versioned download to `seam.exe`, exposed via `bin`.
- The manifest includes `checkver` and `autoupdate` sections, so it can be dropped into a Scoop bucket (own bucket or a community-bucket submission) later with no changes.
- The manifest was validated against Scoop's official schema, generated locally from the real v0.29.0 release data.
- The first release cut after this merges will be the first to carry the `seam.json` asset; the `releases/latest/download/seam.json` URL resolves from then on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtYdE6UGg6ZR7ieqS5YpHt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtYdE6UGg6ZR7ieqS5YpHt)_