### PR TITLE
feat: update blueprint and types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@seamapi/blueprint": "1.8.0",
+        "@seamapi/blueprint": "1.9.1",
         "@seamapi/http": "^2.16.0",
         "chalk": "^6.0.0",
         "command-line-usage": "^7.0.4",
@@ -25,7 +25,7 @@
         "seam": "bin/cli.js"
       },
       "devDependencies": {
-        "@seamapi/types": "^1.994.0",
+        "@seamapi/types": "^1.1047.0",
         "@types/command-line-usage": "^5.0.4",
         "@types/minimist": "^1.2.5",
         "@types/node": "^24.10.9",
@@ -3697,9 +3697,9 @@
       "license": "MIT"
     },
     "node_modules/@seamapi/blueprint": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.8.0.tgz",
-      "integrity": "sha512-NUghBmYaKreBeBxwPIB2O9hjIFZtEjVj73tAsuKdJR8t4BxlKK1I0XDQXxo3ZsH2QezNlbdo9/0MoX/33VXuhQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.9.1.tgz",
+      "integrity": "sha512-A9H3dZE9f+ZEEnOAlMl5jSlL5F/RIKkjOF8NDFbnuahAiu/trDz/RzHOGhbQd6sd0RErIyx3eG1p4HCOJDKDCA==",
       "license": "MIT",
       "dependencies": {
         "change-case": "^5.4.4",
@@ -3726,9 +3726,9 @@
       }
     },
     "node_modules/@seamapi/types": {
-      "version": "1.1039.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/types/-/types-1.1039.0.tgz",
-      "integrity": "sha512-mSAwhtc353ZE0/jtFp45yzmBpF92YhkRUrZrmHmZxZkqXUGicec4pKiW14sryGdWm3ZMerEGihadjrZ0Yf1ueQ==",
+      "version": "1.1047.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/types/-/types-1.1047.0.tgz",
+      "integrity": "sha512-S3A3FcQ4fWJ1IsxVjHaE14k7WlQt0iKJsb3oPF/YVUZHJAmHnFg6riAF6LghlMig7prLf6C2uxaTDairw5dCJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",
-    "@seamapi/blueprint": "1.8.0",
+    "@seamapi/blueprint": "1.9.1",
     "@seamapi/http": "^2.16.0",
     "chalk": "^6.0.0",
     "command-line-usage": "^7.0.4",
@@ -106,7 +106,7 @@
     "tar": "^7.5.22"
   },
   "devDependencies": {
-    "@seamapi/types": "^1.994.0",
+    "@seamapi/types": "^1.1047.0",
     "@types/command-line-usage": "^5.0.4",
     "@types/minimist": "^1.2.5",
     "@types/node": "^24.10.9",


### PR DESCRIPTION
## Summary

- update `@seamapi/blueprint` to 1.9.1
- update `@seamapi/types` to 1.1047.0
- preserve the existing exact or caret version policy

## Testing

- `npm run typecheck`